### PR TITLE
add methods open & close to everipediaiq

### DIFF
--- a/everipediaiq/everipediaiq.abi
+++ b/everipediaiq/everipediaiq.abi
@@ -1,12 +1,6 @@
 {
-    "____comment": "This file was generated with eosio-abigen. DO NOT EDIT ",
+    "____comment": "This file was generated with eosio-abigen. DO NOT EDIT",
     "version": "eosio::abi/1.1",
-    "types": [
-        {
-            "new_type_name": "ipfshash_t",
-            "type": "string"
-        }
-    ],
     "structs": [
         {
             "name": "account",
@@ -14,7 +8,7 @@
             "fields": [
                 {
                     "name": "balance",
-                    "type": "asset"
+                    "type": "int32"
                 }
             ]
         },
@@ -24,15 +18,29 @@
             "fields": [
                 {
                     "name": "from",
-                    "type": "name"
+                    "type": "int32"
                 },
                 {
                     "name": "quantity",
-                    "type": "asset"
+                    "type": "int32"
                 },
                 {
                     "name": "memo",
                     "type": "string"
+                }
+            ]
+        },
+        {
+            "name": "close",
+            "base": "",
+            "fields": [
+                {
+                    "name": "owner",
+                    "type": "int32"
+                },
+                {
+                    "name": "symbol",
+                    "type": "int32"
                 }
             ]
         },
@@ -42,11 +50,11 @@
             "fields": [
                 {
                     "name": "issuer",
-                    "type": "name"
+                    "type": "int32"
                 },
                 {
                     "name": "maximum_supply",
-                    "type": "asset"
+                    "type": "int32"
                 }
             ]
         },
@@ -56,15 +64,15 @@
             "fields": [
                 {
                     "name": "supply",
-                    "type": "asset"
+                    "type": "int32"
                 },
                 {
                     "name": "max_supply",
-                    "type": "asset"
+                    "type": "int32"
                 },
                 {
                     "name": "issuer",
-                    "type": "name"
+                    "type": "int32"
                 }
             ]
         },
@@ -74,7 +82,7 @@
             "fields": [
                 {
                     "name": "proposer",
-                    "type": "name"
+                    "type": "int32"
                 },
                 {
                     "name": "slug",
@@ -102,7 +110,7 @@
                 },
                 {
                     "name": "permission",
-                    "type": "name"
+                    "type": "int32"
                 }
             ]
         },
@@ -112,7 +120,7 @@
             "fields": [
                 {
                     "name": "proposer",
-                    "type": "name"
+                    "type": "int32"
                 },
                 {
                     "name": "slug",
@@ -140,7 +148,7 @@
                 },
                 {
                     "name": "permission",
-                    "type": "name"
+                    "type": "int32"
                 },
                 {
                     "name": "proxied_for",
@@ -158,7 +166,7 @@
             "fields": [
                 {
                     "name": "voter",
-                    "type": "name"
+                    "type": "int32"
                 },
                 {
                     "name": "proposal_id",
@@ -182,7 +190,7 @@
                 },
                 {
                     "name": "permission",
-                    "type": "name"
+                    "type": "int32"
                 }
             ]
         },
@@ -192,7 +200,7 @@
             "fields": [
                 {
                     "name": "voter",
-                    "type": "name"
+                    "type": "int32"
                 },
                 {
                     "name": "proposal_id",
@@ -216,7 +224,7 @@
                 },
                 {
                     "name": "permission",
-                    "type": "name"
+                    "type": "int32"
                 },
                 {
                     "name": "proxied_for",
@@ -234,11 +242,11 @@
             "fields": [
                 {
                     "name": "to",
-                    "type": "name"
+                    "type": "int32"
                 },
                 {
                     "name": "quantity",
-                    "type": "asset"
+                    "type": "int32"
                 },
                 {
                     "name": "memo",
@@ -252,11 +260,11 @@
             "fields": [
                 {
                     "name": "to",
-                    "type": "name"
+                    "type": "int32"
                 },
                 {
                     "name": "quantity",
-                    "type": "asset"
+                    "type": "int32"
                 },
                 {
                     "name": "memo",
@@ -273,20 +281,38 @@
             ]
         },
         {
+            "name": "open",
+            "base": "",
+            "fields": [
+                {
+                    "name": "owner",
+                    "type": "int32"
+                },
+                {
+                    "name": "symbol",
+                    "type": "int32"
+                },
+                {
+                    "name": "ram_payer",
+                    "type": "int32"
+                }
+            ]
+        },
+        {
             "name": "transfer",
             "base": "",
             "fields": [
                 {
                     "name": "from",
-                    "type": "name"
+                    "type": "int32"
                 },
                 {
                     "name": "to",
-                    "type": "name"
+                    "type": "int32"
                 },
                 {
                     "name": "quantity",
-                    "type": "asset"
+                    "type": "int32"
                 },
                 {
                     "name": "memo",
@@ -300,15 +326,15 @@
             "fields": [
                 {
                     "name": "from",
-                    "type": "name"
+                    "type": "int32"
                 },
                 {
                     "name": "to",
-                    "type": "name"
+                    "type": "int32"
                 },
                 {
                     "name": "quantity",
-                    "type": "asset"
+                    "type": "int32"
                 },
                 {
                     "name": "memo",
@@ -329,11 +355,22 @@
             ]
         }
     ],
+    "types": [
+        {
+            "new_type_name": "ipfshash_t",
+            "type": "string"
+        }
+    ],
     "actions": [
         {
             "name": "burn",
             "type": "burn",
             "ricardian_contract": "Burn IQ tokens and take them out of circulation."
+        },
+        {
+            "name": "close",
+            "type": "close",
+            "ricardian_contract": "Close IQ balance."
         },
         {
             "name": "create",
@@ -371,6 +408,11 @@
             "ricardian_contract": "Issue IQ tokens. New version"
         },
         {
+            "name": "open",
+            "type": "open",
+            "ricardian_contract": "Open IQ balance."
+        },
+        {
             "name": "transfer",
             "type": "transfer",
             "ricardian_contract": "Transfer the IQ token."
@@ -383,14 +425,14 @@
     ],
     "tables": [
         {
-            "name": "accounts",
+            "name": "account",
             "type": "account",
             "index_type": "i64",
             "key_names": [],
             "key_types": []
         },
         {
-            "name": "stat",
+            "name": "currency_stats",
             "type": "currency_stats",
             "index_type": "i64",
             "key_names": [],
@@ -398,5 +440,6 @@
         }
     ],
     "ricardian_clauses": [],
-    "variants": []
+    "variants": [],
+    "abi_extensions": []
 }

--- a/everipediaiq/everipediaiq.abi
+++ b/everipediaiq/everipediaiq.abi
@@ -1,6 +1,12 @@
 {
-    "____comment": "This file was generated with eosio-abigen. DO NOT EDIT",
+    "____comment": "This file was generated with eosio-abigen. DO NOT EDIT ",
     "version": "eosio::abi/1.1",
+    "types": [
+        {
+            "new_type_name": "ipfshash_t",
+            "type": "string"
+        }
+    ],
     "structs": [
         {
             "name": "account",
@@ -8,7 +14,7 @@
             "fields": [
                 {
                     "name": "balance",
-                    "type": "int32"
+                    "type": "asset"
                 }
             ]
         },
@@ -18,11 +24,11 @@
             "fields": [
                 {
                     "name": "from",
-                    "type": "int32"
+                    "type": "name"
                 },
                 {
                     "name": "quantity",
-                    "type": "int32"
+                    "type": "asset"
                 },
                 {
                     "name": "memo",
@@ -36,11 +42,11 @@
             "fields": [
                 {
                     "name": "owner",
-                    "type": "int32"
+                    "type": "name"
                 },
                 {
                     "name": "symbol",
-                    "type": "int32"
+                    "type": "symbol"
                 }
             ]
         },
@@ -50,11 +56,11 @@
             "fields": [
                 {
                     "name": "issuer",
-                    "type": "int32"
+                    "type": "name"
                 },
                 {
                     "name": "maximum_supply",
-                    "type": "int32"
+                    "type": "asset"
                 }
             ]
         },
@@ -64,15 +70,15 @@
             "fields": [
                 {
                     "name": "supply",
-                    "type": "int32"
+                    "type": "asset"
                 },
                 {
                     "name": "max_supply",
-                    "type": "int32"
+                    "type": "asset"
                 },
                 {
                     "name": "issuer",
-                    "type": "int32"
+                    "type": "name"
                 }
             ]
         },
@@ -82,7 +88,7 @@
             "fields": [
                 {
                     "name": "proposer",
-                    "type": "int32"
+                    "type": "name"
                 },
                 {
                     "name": "slug",
@@ -110,7 +116,7 @@
                 },
                 {
                     "name": "permission",
-                    "type": "int32"
+                    "type": "name"
                 }
             ]
         },
@@ -120,7 +126,7 @@
             "fields": [
                 {
                     "name": "proposer",
-                    "type": "int32"
+                    "type": "name"
                 },
                 {
                     "name": "slug",
@@ -148,7 +154,7 @@
                 },
                 {
                     "name": "permission",
-                    "type": "int32"
+                    "type": "name"
                 },
                 {
                     "name": "proxied_for",
@@ -166,7 +172,7 @@
             "fields": [
                 {
                     "name": "voter",
-                    "type": "int32"
+                    "type": "name"
                 },
                 {
                     "name": "proposal_id",
@@ -190,7 +196,7 @@
                 },
                 {
                     "name": "permission",
-                    "type": "int32"
+                    "type": "name"
                 }
             ]
         },
@@ -200,7 +206,7 @@
             "fields": [
                 {
                     "name": "voter",
-                    "type": "int32"
+                    "type": "name"
                 },
                 {
                     "name": "proposal_id",
@@ -224,7 +230,7 @@
                 },
                 {
                     "name": "permission",
-                    "type": "int32"
+                    "type": "name"
                 },
                 {
                     "name": "proxied_for",
@@ -242,11 +248,11 @@
             "fields": [
                 {
                     "name": "to",
-                    "type": "int32"
+                    "type": "name"
                 },
                 {
                     "name": "quantity",
-                    "type": "int32"
+                    "type": "asset"
                 },
                 {
                     "name": "memo",
@@ -260,11 +266,11 @@
             "fields": [
                 {
                     "name": "to",
-                    "type": "int32"
+                    "type": "name"
                 },
                 {
                     "name": "quantity",
-                    "type": "int32"
+                    "type": "asset"
                 },
                 {
                     "name": "memo",
@@ -286,15 +292,15 @@
             "fields": [
                 {
                     "name": "owner",
-                    "type": "int32"
+                    "type": "name"
                 },
                 {
                     "name": "symbol",
-                    "type": "int32"
+                    "type": "symbol"
                 },
                 {
                     "name": "ram_payer",
-                    "type": "int32"
+                    "type": "name"
                 }
             ]
         },
@@ -304,15 +310,15 @@
             "fields": [
                 {
                     "name": "from",
-                    "type": "int32"
+                    "type": "name"
                 },
                 {
                     "name": "to",
-                    "type": "int32"
+                    "type": "name"
                 },
                 {
                     "name": "quantity",
-                    "type": "int32"
+                    "type": "asset"
                 },
                 {
                     "name": "memo",
@@ -326,15 +332,15 @@
             "fields": [
                 {
                     "name": "from",
-                    "type": "int32"
+                    "type": "name"
                 },
                 {
                     "name": "to",
-                    "type": "int32"
+                    "type": "name"
                 },
                 {
                     "name": "quantity",
-                    "type": "int32"
+                    "type": "asset"
                 },
                 {
                     "name": "memo",
@@ -355,19 +361,13 @@
             ]
         }
     ],
-    "types": [
-        {
-            "new_type_name": "ipfshash_t",
-            "type": "string"
-        }
-    ],
     "actions": [
         {
             "name": "burn",
             "type": "burn",
             "ricardian_contract": "Burn IQ tokens and take them out of circulation."
         },
-        {
+       {
             "name": "close",
             "type": "close",
             "ricardian_contract": "Close IQ balance."
@@ -425,14 +425,14 @@
     ],
     "tables": [
         {
-            "name": "account",
+            "name": "accounts",
             "type": "account",
             "index_type": "i64",
             "key_names": [],
             "key_types": []
         },
         {
-            "name": "currency_stats",
+            "name": "stat",
             "type": "currency_stats",
             "index_type": "i64",
             "key_names": [],
@@ -440,6 +440,5 @@
         }
     ],
     "ricardian_clauses": [],
-    "variants": [],
-    "abi_extensions": []
+    "variants": []
 }

--- a/everipediaiq/everipediaiq.contracts.md
+++ b/everipediaiq/everipediaiq.contracts.md
@@ -6,6 +6,10 @@ Transfer the IQ token normally, with extra information recorded. The regular tra
 Burn IQ tokens and take them out of circulation.
 <h1 class="contract">issue</h1>
 Issue IQ tokens.
+<h1 class="contract">open</h1>
+Open IQ balance.
+<h1 class="contract">close</h1>
+Close IQ balance.
 <h1 class="contract">issueextra</h1>
 Issue IQ tokens. New version
 <h1 class="contract">brainmeiq</h1>

--- a/everipediaiq/everipediaiq.hpp
+++ b/everipediaiq/everipediaiq.hpp
@@ -50,6 +50,12 @@ class [[eosio::contract("everipediaiq")]] everipediaiq : public contract {
     void issue( name to, asset quantity, string memo );
 
     [[eosio::action]]
+    void open( const name& owner, const symbol& symbol, const name& ram_payer );
+
+    [[eosio::action]]
+    void close( const name& owner, const symbol& symbol );
+
+    [[eosio::action]]
     void issueextra( 
       name to, 
       asset quantity, 


### PR DESCRIPTION
it needs to follow eosio.token standards in order to work with some dapps like mindswap, evodex, and others where ram is managed by user.

Without these functionalities, contracts needs to pay for the ram of transfering first IQs to an account, something that can be exploited by malicious users taking all the RAM from the initial contract and making it unusable.

![image](https://user-images.githubusercontent.com/1288106/103877513-7e2bfc00-50d5-11eb-951a-7025e6d5fbca.png)

![image](https://user-images.githubusercontent.com/1288106/103877597-97cd4380-50d5-11eb-8ba4-417601dbcab7.png)

methods copied from original  ( https://github.com/EOSIO/eosio.contracts/blob/master/contracts/eosio.token/src/eosio.token.cpp#L129 ) 

This branch needs testing in Kylin before merging it, because I wasn't able to build, deploy & test it there 